### PR TITLE
Lower the version requirement for cmake

### DIFF
--- a/grpc/CMakeLists.txt
+++ b/grpc/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1.0)
+cmake_minimum_required(VERSION 2.8.12)
 include(ExternalProject)
 project(grpc)
 


### PR DESCRIPTION
Merge to ROS repo failed because of cmake version requirement too high (#3). Lowering to 2.8.12.

Still testing with ros:indigo image.