### PR TITLE
Depend on absolute path of .proto file

### DIFF
--- a/grpc/cmake/generate_proto.cmake
+++ b/grpc/cmake/generate_proto.cmake
@@ -120,8 +120,6 @@ function(generate_proto PROTO_TARGET_NAME)
     # FILE_RELPATH_BASE is the relative file path to base.
     file(RELATIVE_PATH FILE_RELPATH_BASE
          ${SRC_RELATIVE_BASE_DIR} ${ABS_FILE_PATH})
-    file(RELATIVE_PATH FILE_RELPATH_PROJECT_SRC
-         ${PROJECT_SOURCE_DIR} ${ABS_FILE_PATH})
     get_filename_component(DIR_FILE ${FILE_RELPATH_BASE} DIRECTORY)
 
     # DEST_STAMP_FILE is stamp file to mark execution of protoc.
@@ -184,7 +182,7 @@ function(generate_proto PROTO_TARGET_NAME)
              ${ABS_FILE_PATH}
       COMMAND ${CMAKE_COMMAND}
         ARGS -E touch ${DEST_STAMP_FILE}
-      DEPENDS ${FILE_RELPATH_PROJECT_SRC}
+      DEPENDS ${ABS_FILE_PATH}
       COMMENT "Running protocol buffer compiler on \"${PROTO_FILE}\"."
       VERBATIM
     )


### PR DESCRIPTION
This should fix #20. The original concern was for some reason cmake re-generate protos if .proto is not within src. Initial test shows this is not the case, but should do more tests.