### PR TITLE
Use build_depend instead of depend

### DIFF
--- a/grpc/package.xml
+++ b/grpc/package.xml
@@ -10,6 +10,6 @@
   <build_depend>rsync</build_depend>
   <build_depend>git</build_depend>
   <build_depend>zlib</build_depend>
+  <build_depend>rsync</build_depend>
   <buildtool_depend>catkin</buildtool_depend>
-  <depend>rsync</depend>
 </package>


### PR DESCRIPTION
**Problem Description**
This PR fixes a build failure with the error as the following. 
```
Error(s):
- The manifest of package "grpc" (with format version 1) must not contain the following tags: depend
```
This problem was caused by https://github.com/CogRob/catkin_grpc/pull/44, where the `<depend>` flag is only available on the package manifest format 2 (https://www.ros.org/reps/rep-0140.html#adding-depend) and the package.xml format used in this package is still on format 1

@tomlankhorst FYI