### PR TITLE
[ROS-O] Bump grpc version to v1.48.4

### DIFF
--- a/grpc/CMakeLists.txt
+++ b/grpc/CMakeLists.txt
@@ -20,7 +20,7 @@ ExternalProject_Add(
   build_grpc
   PREFIX grpc
   GIT_REPOSITORY "https://github.com/grpc/grpc.git"
-  GIT_TAG v1.34.1
+  GIT_TAG v1.48.4
   GIT_CONFIG submodule.recurse=1 submodule.fetchJobs=10
   GIT_SHALLOW 1
   SOURCE_DIR grpc_build


### PR DESCRIPTION
Bump gRPC library version to resolve ABSL library build failure with Ubuntu 24.04

The current version of the gRPC library is causing build issues due to the incompatibility of the ABSL library with Ubuntu 24.04.
To resolve this issue, I am bumping the version of the gRPC library to the earliest version that is compatible with Ubuntu 24.04.

I have tested the updated gRPC library version and confirmed that it works both with Ubuntu 24.04 and with 20.04 (noetic).
