### PR TITLE
Use submodule instead of ExternalProject_Add

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "grpc/grpc"]
+	shallow = true
+	path = grpc/grpc
+	url = https://github.com/grpc/grpc.git

--- a/grpc/CMakeLists.txt
+++ b/grpc/CMakeLists.txt
@@ -88,13 +88,13 @@ add_custom_command(
     ${RSYNC}
       --prune-empty-dirs --archive
       --include="*/" --include="*.proto" --exclude="*"
-      ${CMAKE_CURRENT_BINARY_DIR}/grpc_build/src/proto/
+      ${GRPC_BUILD_SOURCE_DIR}/src/proto/
       ${GRPC_INCLUDE_DESTINATION}/src/proto/
   COMMAND
     ${RSYNC}
       --prune-empty-dirs --archive
       --include="*/" --include="*.h" --exclude="*"
-      ${CMAKE_CURRENT_BINARY_DIR}/grpc_build/gens/src/proto/
+      ${GRPC_BUILD_SOURCE_DIR}/gens/src/proto/
       ${GRPC_INCLUDE_DESTINATION}/src/proto/
   COMMAND
     ${RSYNC}
@@ -106,7 +106,7 @@ add_custom_command(
     ${RSYNC}
       --prune-empty-dirs --archive
       --include="*/" --include="*.h" --include="*.inc" --include="*.proto" --exclude="*"
-      ${CMAKE_CURRENT_BINARY_DIR}/grpc_build/third_party/protobuf/src/
+      ${GRPC_BUILD_SOURCE_DIR}/third_party/protobuf/src/
       ${GRPC_INCLUDE_DESTINATION}/
   COMMAND
     ${RSYNC}

--- a/grpc/CMakeLists.txt
+++ b/grpc/CMakeLists.txt
@@ -15,15 +15,22 @@ if(NOT RSYNC)
   message(SEND_ERROR "Cannot find rsync.")
 endif(NOT RSYNC)
 
+set(GRPC_BUILD_SOURCE_DIR "${CMAKE_CURRENT_BINARY_DIR}/grpc_build")
 set(GRPC_BUILD_INSTALL_DIR ${CMAKE_CURRENT_BINARY_DIR}/grpc_install)
 ExternalProject_Add(
   build_grpc
   PREFIX grpc
-  GIT_REPOSITORY "https://github.com/grpc/grpc.git"
-  GIT_TAG v1.48.4
-  GIT_CONFIG submodule.recurse=1 submodule.fetchJobs=3
-  GIT_SHALLOW 1
-  SOURCE_DIR grpc_build
+
+  # Copy grpc submodule to build directory to use artifact objects in the source directory.
+  # BUILD_IN_SOURCE 1 allows ExternalProject_Add() to generates the artifact objects in the
+  # source directory.
+  DOWNLOAD_COMMAND
+  ${RSYNC}
+  --prune-empty-dirs --archive
+  ${CMAKE_SOURCE_DIR}/grpc/ ${GRPC_BUILD_SOURCE_DIR}/
+
+  SOURCE_DIR ${GRPC_BUILD_SOURCE_DIR}
+
   CMAKE_ARGS
   -DBUILD_SHARED_LIBS=ON
   -DBUILD_TESTING=OFF


### PR DESCRIPTION
* Using `ExternalProject_Add` in buildtime is not stable sometimes. Instead, use submodule to clone grpc source code.