### PR TITLE
Add package to test grpc

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,29 @@
+name: Test
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    env:
+      CCACHE_DIR: "${{ github.workspace }}/.ccache"
+      ROS_DISTRO: noetic
+    steps:
+      - name: Checkout the project
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          fetch-depth: 0
+      - uses: actions/cache@v4
+        with:
+          path: ${{ env.CCACHE_DIR }}
+          key: ccache-${{ github.run_id }}
+          restore-keys: |
+            ccache-${{ matrix.ROS_DISTRO }}-${{ matrix.ROS_REPO }}-
+      - name: Build and test the packages
+        uses: ros-industrial/industrial_ci@0.10.0

--- a/test_grpc/CMakeLists.txt
+++ b/test_grpc/CMakeLists.txt
@@ -13,9 +13,23 @@ find_package(catkin REQUIRED COMPONENTS
   roscpp
 )
 
-file(REAL_PATH "${grpc_DIR}/../../../lib" grpc_LIBRARY_DIR)
+function(realpath path var)
+  if(CMAKE_VERSION VERSION_LESS 3.19)
+    find_program(REALPATH realpath REQUIRED)
+    execute_process(
+      COMMAND "${REALPATH}" "${path}"
+      OUTPUT_VARIABLE realpath_output
+      OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+  else()
+    file(REAL_PATH "${grpc_DIR}/../../../lib" realpath_output)
+  endif()
+  set("${var}" "${realpath_output}" PARENT_SCOPE)
+endfunction()
+
+realpath("${grpc_DIR}/../../../lib" grpc_LIBRARY_DIR)
 function(assert_grpc_library lib)
-  file(REAL_PATH "${lib}" LIBRARY)
+  realpath("${lib}" LIBRARY)
   string(FIND "${grpc_LIBRARY_DIR}" "${LIBRARY}" index)
   if(index LESS 0)
     message(DEBUG "${LIBRARY} is system library")

--- a/test_grpc/CMakeLists.txt
+++ b/test_grpc/CMakeLists.txt
@@ -1,0 +1,69 @@
+cmake_minimum_required(VERSION 3.0.2)
+project(test_grpc)
+
+# Check if the libraries installed when building the package `grpc`
+# do not have name collisions with system libraries
+find_library(LIB_Z z REQUIRED)
+find_library(LIB_SSL ssl REQUIRED)
+find_library(LIB_CRYPTO crypto REQUIRED)
+find_library(LIB_PROTOC protoc)
+
+find_package(catkin REQUIRED COMPONENTS
+  grpc
+  roscpp
+)
+
+file(REAL_PATH "${grpc_DIR}/../../../lib" grpc_LIBRARY_DIR)
+function(assert_grpc_library lib)
+  file(REAL_PATH "${lib}" LIBRARY)
+  string(FIND "${grpc_LIBRARY_DIR}" "${LIBRARY}" index)
+  if(index LESS 0)
+    message(DEBUG "${LIBRARY} is system library")
+  else()
+    message(FATAL_ERROR
+      "${LIBRARY} is subdir of ${grpc_LIBRARY_DIR}"
+      " and overrides the system library")
+  endif()
+endfunction()
+assert_grpc_library(${LIB_Z})
+assert_grpc_library(${LIB_SSL})
+assert_grpc_library(${LIB_CRYPTO})
+if(LIB_PROTOC)
+  assert_grpc_library(${LIB_PROTOC})
+endif()
+
+# Using libgrpc++_unsecure.so instead of libgrpc++.so because grpc initialization process can
+# hang up if libgrpc++.so is used.
+list(FILTER ALL_GRPC_LIBS EXCLUDE REGEX "^.*libgrpc\\+\\+\\.so$")
+# so as the libgrpc_unsecure.so and libgrpc.so
+list(FILTER ALL_GRPC_LIBS EXCLUDE REGEX "^.*libgrpc\\.so$")
+
+catkin_package(CATKIN_DEPENDS grpc)
+
+set(CMAKE_CXX_STANDARD 17)
+
+generate_proto(${PROJECT_NAME}
+  GRPC
+  FILES protos/Header.proto grpcs/Chat.proto
+)
+
+include_directories(${catkin_INCLUDE_DIRS})
+add_executable(chat_server src/chat_server.cpp)
+target_link_libraries(chat_server ${catkin_LIBRARIES} ${ALL_PROTOBUF_LIBS} ${ALL_GRPC_LIBS} ${PROJECT_NAME})
+add_executable(chat_client src/chat_client.cpp)
+target_link_libraries(chat_client ${catkin_LIBRARIES} ${ALL_PROTOBUF_LIBS} ${ALL_GRPC_LIBS} ${PROJECT_NAME})
+
+install(TARGETS chat_server chat_client
+  ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
+
+install(DIRECTORY tests
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+  USE_SOURCE_PERMISSIONS)
+
+if(CATKIN_ENABLE_TESTING)
+  find_package(rostest REQUIRED)
+  add_rostest(tests/test_chat_service.test)
+endif()
+  

--- a/test_grpc/grpcs/Chat.proto
+++ b/test_grpc/grpcs/Chat.proto
@@ -1,0 +1,14 @@
+syntax = "proto3";
+
+package test_grpc.grpcs;
+import "test_grpc/protos/Header.proto";
+
+message Message {
+  test_grpc.protos.Header header = 1;
+  int32 sender = 2;
+  string body = 3;
+}
+
+service Chat {
+  rpc Echo (Message) returns (Message);
+}

--- a/test_grpc/package.xml
+++ b/test_grpc/package.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<package format="2">
+  <name>test_grpc</name>
+  <version>0.0.0</version>
+  <description>A package for testing the grpc package</description>
+  <maintainer email="furushchev@gmail.com">Yuki Furuta</maintainer>
+  <license>BSD</license>
+  <author email="furushchev@gmail.com">Yuki Furuta</author>
+  <buildtool_depend>catkin</buildtool_depend>
+  <depend>grpc</depend>
+  <test_depend>rostest</test_depend>
+</package>

--- a/test_grpc/protos/Header.proto
+++ b/test_grpc/protos/Header.proto
@@ -1,0 +1,10 @@
+syntax = "proto3";
+
+package test_grpc.protos;
+import "google/protobuf/timestamp.proto";
+
+message Header {
+  int64 seq = 1;
+  google.protobuf.Timestamp stamp = 2;
+  string frame_id = 3;
+}

--- a/test_grpc/src/chat_client.cpp
+++ b/test_grpc/src/chat_client.cpp
@@ -1,0 +1,75 @@
+#include <grpcpp/grpcpp.h>
+#include <ros/ros.h>
+#include <std_msgs/String.h>
+#include <test_grpc/grpcs/Chat.grpc.pb.h>
+
+namespace test_grpc
+{
+void chatClient(ros::NodeHandle& nh)
+{
+  ros::Publisher response_pub = nh.advertise<std_msgs::String>("response", 1, true);
+
+  const std::string client_address =
+    nh.param<std::string>("client_address", "127.0.0.1:50000");
+
+  std::shared_ptr<grpc::Channel> channel =
+      grpc::CreateChannel(client_address, grpc::InsecureChannelCredentials());
+  ROS_INFO_STREAM("Connecting to " << client_address);
+  std::chrono::system_clock::time_point deadline =
+      std::chrono::system_clock::now() + std::chrono::seconds(10);
+  if (!channel->WaitForConnected(deadline))
+  {
+    ROS_ERROR_STREAM("Waiting for server timedout");
+    return;
+  }
+  ROS_INFO_STREAM("Connected to " << client_address);
+
+  std::unique_ptr<grpcs::Chat::Stub> stub(
+      grpcs::Chat::NewStub(channel));
+
+  grpc::ClientContext ctx;
+  grpcs::Message request;
+  grpcs::Message response;
+
+  auto stamp = request.mutable_header()->mutable_stamp();
+  auto now = ros::Time::now();
+  stamp->set_seconds(now.sec);
+  stamp->set_nanos(now.nsec);
+  request.set_sender(1);
+  request.set_body("foo");
+
+  grpc::Status status = stub->Echo(&ctx, request, &response);
+  if (status.ok())
+  {
+    ROS_INFO_STREAM("response received " << response.body() << " from " << response.sender());
+    if (request.body() == response.body())
+    {
+      std_msgs::String msg;
+      msg.data = response.body();
+      // wait for test subscriber
+      ros::Duration(1).sleep();
+      response_pub.publish(msg);
+      // wait for publish
+      ros::Duration(10).sleep();
+    }
+    else
+    {
+      ROS_ERROR_STREAM("received response mismatch: " << request.body()
+                                                      << " != " << response.body());
+    }
+  }
+  else
+  {
+    ROS_ERROR_STREAM("Echo service returned error " << static_cast<int>(status.error_code()) << ": "
+                                                    << status.error_message());
+  }
+}
+}
+
+int main(int argc, char** argv)
+{
+  ros::init(argc, argv, "chat_client");
+  ros::NodeHandle pnh("~");
+  test_grpc::chatClient(pnh);
+  return 0;
+}

--- a/test_grpc/src/chat_server.cpp
+++ b/test_grpc/src/chat_server.cpp
@@ -1,0 +1,80 @@
+#include <memory>
+#include <thread>
+
+#include <test_grpc/grpcs/Chat.grpc.pb.h>
+#include <grpcpp/grpcpp.h>
+#include <ros/ros.h>
+
+namespace test_grpc
+{
+class ChatServer final : public grpcs::Chat::Service
+{
+public:
+  explicit ChatServer(const int port) : m_port(port), m_seq(0), m_thread(), m_server() {}
+
+  ~ChatServer() {}
+
+  grpc::Status Echo(grpc::ServerContext* ctx, const grpcs::Message* request,
+                    grpcs::Message* response) override
+  {
+    ROS_INFO_STREAM("received " << request->body() << " from " << request->sender());
+
+    auto now = ros::Time::now();
+    auto stamp = response->mutable_header()->mutable_stamp();
+    stamp->set_seconds(now.sec);
+    stamp->set_nanos(now.nsec);
+    response->mutable_header()->set_seq(m_seq++);
+    response->set_sender(2);
+    response->set_body(request->body());
+    return grpc::Status::OK;
+  }
+
+  void start()
+  {
+    m_thread = std::thread([this]() {
+      grpc::ServerBuilder builder;
+      builder.SetMaxReceiveMessageSize(std::numeric_limits<int>::max());
+      builder.SetMaxSendMessageSize(std::numeric_limits<int>::max());
+      builder.AddListeningPort("0.0.0.0:" + std::to_string(m_port),
+                               grpc::InsecureServerCredentials());
+      builder.RegisterService(this);
+      m_server = builder.BuildAndStart();
+      ROS_INFO_STREAM("Waiting for gRPC client using port " << m_port);
+      m_server->Wait();
+      ROS_INFO_STREAM("Stop waiting for gRPC client using port " << m_port);
+    });
+  }
+
+  void stop() {
+    if (m_server) {
+      const auto deadline = std::chrono::system_clock::now() + std::chrono::seconds(1);
+      m_server->Shutdown(deadline);
+    }
+    if (m_thread.joinable())
+    {
+      m_thread.join();
+    }
+  }
+
+private:
+  int m_port;
+  int m_seq;
+  std::thread m_thread;
+  std::unique_ptr<grpc::Server> m_server;
+};
+}
+
+int main(int argc, char** argv)
+{
+  ros::init(argc, argv, "chat_server");
+
+  ros::NodeHandle pnh("~");
+  const int server_port = pnh.param<int>("server_port", 50000);
+
+  test_grpc::ChatServer server(server_port);
+  server.start();
+  ros::spin();
+  server.stop();
+
+  return 0;
+}

--- a/test_grpc/tests/test_chat_service.test
+++ b/test_grpc/tests/test_chat_service.test
@@ -1,0 +1,25 @@
+<launch>
+  <arg name="port" default="50000"/>
+
+  <node name="chat_server" pkg="test_grpc" type="chat_server"
+        output="screen">
+    <rosparam subst_value="true">
+      server_port: $(arg port)
+    </rosparam>
+  </node>
+
+  <node name="chat_client" pkg="test_grpc" type="chat_client"
+        output="screen">
+    <rosparam subst_value="true">
+      client_address: 'localhost:$(arg port)'
+    </rosparam>
+  </node>
+
+  <test test-name="test_chat_service" pkg="rostest" type="publishtest">
+    <rosparam>
+      topics:
+      - name: chat_client/response
+        timeout: 10
+    </rosparam>
+  </test>
+</launch>


### PR DESCRIPTION
This pull request introduces a new test package `test_grpc` to verify the functionality of the `generate_proto` function within the `grpc` package.

These tests are designed to ensure:
- Both ROS and gRPC functionalities can be compiled and operate as expected.
- The previous issue https://github.com/CogRob/catkin_grpc/pull/54, where other packages were incorrectly referencing system libraries instead of the intended gRPC dependent libraries, is also checked in this package.
- Enables Github Actions for automating the tests

I checked the workflow worked in my forked repository: https://github.com/furushchev/catkin_grpc/actions/runs/13255731551/job/37002195362