### PR TITLE
Allow users setting CXX standard

### DIFF
--- a/grpc/CMakeLists.txt
+++ b/grpc/CMakeLists.txt
@@ -2,7 +2,9 @@ cmake_minimum_required(VERSION 3.8.2)
 include(ExternalProject)
 project(grpc)
 
-add_compile_options(-std=c++11)
+if(NOT DEFINED CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 17)
+endif()
 
 find_package(catkin REQUIRED)
 

--- a/test_grpc/CMakeLists.txt
+++ b/test_grpc/CMakeLists.txt
@@ -54,7 +54,9 @@ list(FILTER ALL_GRPC_LIBS EXCLUDE REGEX "^.*libgrpc\\.so$")
 
 catkin_package(CATKIN_DEPENDS grpc)
 
-set(CMAKE_CXX_STANDARD 17)
+if(NOT DEFINED CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 17)
+endif()
 
 generate_proto(${PROJECT_NAME}
   GRPC


### PR DESCRIPTION
Although the current version of gRPC bundled with repository requires C++17, it's better for users to allow setting CXX standard.
ref:
https://github.com/moveit/moveit/pull/3043